### PR TITLE
Obscure changelog URLs on Discord to suppress previews

### DIFF
--- a/django/accounts/models.py
+++ b/django/accounts/models.py
@@ -229,7 +229,7 @@ class Squad(models.Model):
             if account is not None:
                 yield account
 
-    def do_changelog_announcements(self, base_url=None, changelog=None):
+    def do_changelog_announcements(self, base_url='', changelog=None):
         if changelog is None:
             from gitinfo import changelog
 
@@ -247,7 +247,7 @@ class Squad(models.Model):
             if len(announcements) > 0:
                 obscure_url = lambda url: base_url + get_redirect_url_to(url)
                 fmt = lambda entry: f'\n\n🚀 **{entry["date"]}:** {entry["message"]} [More info]({obscure_url(entry["url"])})'
-                text = 'I have just received some updats:' + ''.join(fmt(entry) for entry in announcements)
+                text = 'I have just received some updates:' + ''.join(fmt(entry) for entry in announcements)
 
                 from discordbot.models import ScheduledNotification
                 ScheduledNotification.objects.create(squad = self, text = text)

--- a/django/accounts/models.py
+++ b/django/accounts/models.py
@@ -6,6 +6,7 @@ from django.core.validators import RegexValidator
 
 from api import api
 from stats.updater import queue_update_task
+from url_forward import get_redirect_url_to
 
 from datetime import datetime
 
@@ -244,7 +245,7 @@ class Squad(models.Model):
                     announcements.append(entry)
 
             if len(announcements) > 0:
-                fmt = lambda entry: f'\n\n🚀 **{entry["date"]}:** {entry["message"]} [More info]({entry["url"]})'
+                fmt = lambda entry: f'\n\n🚀 **{entry["date"]}:** {entry["message"]} [More info]({get_redirect_url_to(entry["url"])})'
                 text = 'I have just received some updats:' + ''.join(fmt(entry) for entry in announcements)
 
                 from discordbot.models import ScheduledNotification

--- a/django/accounts/models.py
+++ b/django/accounts/models.py
@@ -229,7 +229,7 @@ class Squad(models.Model):
             if account is not None:
                 yield account
 
-    def do_changelog_announcements(self, changelog=None):
+    def do_changelog_announcements(self, base_url=None, changelog=None):
         if changelog is None:
             from gitinfo import changelog
 
@@ -245,7 +245,8 @@ class Squad(models.Model):
                     announcements.append(entry)
 
             if len(announcements) > 0:
-                fmt = lambda entry: f'\n\n🚀 **{entry["date"]}:** {entry["message"]} [More info]({get_redirect_url_to(entry["url"])})'
+                obscure_url = lambda url: base_url + get_redirect_url_to(url)
+                fmt = lambda entry: f'\n\n🚀 **{entry["date"]}:** {entry["message"]} [More info]({obscure_url(entry["url"])})'
                 text = 'I have just received some updats:' + ''.join(fmt(entry) for entry in announcements)
 
                 from discordbot.models import ScheduledNotification

--- a/django/csgo_app/settings/common.py
+++ b/django/csgo_app/settings/common.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     'accounts',
     'stats',
     'discordbot',
+    'url_forward',
 ]
 
 MIDDLEWARE = [

--- a/django/csgo_app/urls.py
+++ b/django/csgo_app/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     path('accounts/', include('accounts.urls')),
     path('stats/', include('stats.urls')),
     path('', RedirectView.as_view(url='stats/')),
+    path('redirect/', include('url_forward.urls')),
 ]

--- a/django/discordbot/bot.py
+++ b/django/discordbot/bot.py
@@ -323,11 +323,11 @@ async def who_is_your_creator(ctx):
 if os.environ.get('CS2PB_DISCORD_ENABLED', False):
     log.info(f'Discord integration enabled')
 
-    for squad in Squad.objects.all():
-        squad.do_changelog_announcements()
-
     with open('discordbot/settings.json') as fin:
         settings = json.load(fin)
+
+    for squad in Squad.objects.all():
+        squad.do_changelog_announcements(base_url = settings['base_url']})
 
     tick_pause = 60 / int(settings['ticks_per_minute'])
     bot.run(settings['token'])

--- a/django/discordbot/bot.py
+++ b/django/discordbot/bot.py
@@ -327,7 +327,7 @@ if os.environ.get('CS2PB_DISCORD_ENABLED', False):
         settings = json.load(fin)
 
     for squad in Squad.objects.all():
-        squad.do_changelog_announcements(base_url = settings['base_url']})
+        squad.do_changelog_announcements(base_url = settings['base_url'])
 
     tick_pause = 60 / int(settings['ticks_per_minute'])
     bot.run(settings['token'])

--- a/django/url_forward/__init__.py
+++ b/django/url_forward/__init__.py
@@ -7,4 +7,3 @@ def get_redirect_url_to(url):
     return reverse('redirect', kwargs = dict(
         encoded_url = urllib.parse.quote_plus(url)
     ))
-

--- a/django/url_forward/__init__.py
+++ b/django/url_forward/__init__.py
@@ -5,5 +5,5 @@ from django.urls import reverse
 
 def get_redirect_url_to(url):
     return reverse('redirect', kwargs = dict(
-        encoded_url = base64.b64decode(url).decode('utf-8')
+        encoded_url = base64.b64encode(url_bytes.encode('utf-8')).decode('utf-8')
     ))

--- a/django/url_forward/__init__.py
+++ b/django/url_forward/__init__.py
@@ -1,9 +1,9 @@
-import urllib
+import base64
 
 from django.urls import reverse
 
 
 def get_redirect_url_to(url):
     return reverse('redirect', kwargs = dict(
-        encoded_url = urllib.parse.quote_plus(url)
+        encoded_url = base64.b64decode(url).decode('utf-8')
     ))

--- a/django/url_forward/__init__.py
+++ b/django/url_forward/__init__.py
@@ -5,5 +5,5 @@ from django.urls import reverse
 
 def get_redirect_url_to(url):
     return reverse('redirect', kwargs = dict(
-        encoded_url = base64.b64encode(url_bytes.encode('utf-8')).decode('utf-8')
+        encoded_url = base64.b64encode(url.encode('utf-8')).decode('utf-8')
     ))

--- a/django/url_forward/__init__.py
+++ b/django/url_forward/__init__.py
@@ -1,0 +1,10 @@
+import urllib
+
+from django.urls import reverse
+
+
+def get_redirect_url_to(url):
+    return reverse('redirect', kwargs = dict(
+        encoded_url = urllib.parse.quote_plus(url)
+    ))
+

--- a/django/url_forward/admin.py
+++ b/django/url_forward/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/django/url_forward/apps.py
+++ b/django/url_forward/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class UrlForwardConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'url_forward'

--- a/django/url_forward/models.py
+++ b/django/url_forward/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/django/url_forward/templates/url_forward/redirect.html
+++ b/django/url_forward/templates/url_forward/redirect.html
@@ -1,6 +1,8 @@
 <html>
 <head>
 
+<title>Redirect</title>
+
 <meta charset="utf-8">
 
 <script language="javascript">

--- a/django/url_forward/templates/url_forward/redirect.html
+++ b/django/url_forward/templates/url_forward/redirect.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+
+<meta charset="utf-8">
+
+<script language="javascript">
+location.href = '{{ url }}';
+</script>
+
+<body>
+
+You are being redirected to: {{ url }}
+
+</body>
+</html>

--- a/django/url_forward/tests.py
+++ b/django/url_forward/tests.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+import url_forward
+
+
+class get_redirect_url_to(TestCase):
+
+    def test(self):
+        actual = url_forward.get_redirect_url_to('https://github.com/kodikit')
+        self.assertEqual(actual, '/redirect/https%253A%252F%252Fgithub.com%252Fkodikit/')
+
+
+class do_redirect(TestCase):
+
+    def test(self):
+        resp = self.client.get('/redirect/https%253A%252F%252Fgithub.com%252Fkodikit/', follow=False)
+        self.assertEqual(resp.url, 'https://github.com/kodikit')

--- a/django/url_forward/tests.py
+++ b/django/url_forward/tests.py
@@ -1,3 +1,5 @@
+import base64
+
 from django.test import TestCase
 
 import url_forward
@@ -6,12 +8,17 @@ import url_forward
 class get_redirect_url_to(TestCase):
 
     def test(self):
-        actual = url_forward.get_redirect_url_to('https://github.com/kodikit')
-        self.assertEqual(actual, '/redirect/https%253A%252F%252Fgithub.com%252Fkodikit/')
+        url = 'https://github.com/kodikit'
+        actual = url_forward.get_redirect_url_to(url)
+        code = base64.b64encode(url.encode('utf-8')).decode('utf-8')
+        self.assertEqual(actual, f'/redirect/{code}/')
 
 
 class do_redirect(TestCase):
 
     def test(self):
-        resp = self.client.get('/redirect/https%253A%252F%252Fgithub.com%252Fkodikit/', follow=False)
-        self.assertEqual(resp.url, 'https://github.com/kodikit')
+        url = 'https://github.com/kodikit'
+        code = base64.b64encode(url.encode('utf-8')).decode('utf-8')
+        resp = self.client.get(f'/redirect/{code}/', follow=False)
+        self.assertContains(resp, 'https://github.com/kodikit', status_code=200)
+        self.assertTemplateUsed(resp, 'url_forward/redirect.html')

--- a/django/url_forward/urls.py
+++ b/django/url_forward/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from . import views
+
+
+urlpatterns = [
+    path('<str:encoded_url>/', views.do_redirect, name='redirect'),
+]

--- a/django/url_forward/views.py
+++ b/django/url_forward/views.py
@@ -1,9 +1,9 @@
-import urllib
+import base64
 
 from django.shortcuts import render
 
 
 def do_redirect(request, encoded_url):
-    url = urllib.parse.unquote_plus(encoded_url)
+    url = base64.b64encode(encoded_url.encode(encoding='utf-8'))
     context = dict(url = url)
     return render(request, 'url_forward/redirect.html', context)

--- a/django/url_forward/views.py
+++ b/django/url_forward/views.py
@@ -1,0 +1,9 @@
+import urllib
+
+from django.shortcuts import redirect
+
+
+def do_redirect(request, encoded_url):
+    url = urllib.parse.unquote_plus(encoded_url)
+    assert url.lower().startswith('http://') or url.lower().startswith('https://'), url
+    return redirect(url)

--- a/django/url_forward/views.py
+++ b/django/url_forward/views.py
@@ -1,9 +1,9 @@
 import urllib
 
-from django.shortcuts import redirect
+from django.shortcuts import render
 
 
 def do_redirect(request, encoded_url):
     url = urllib.parse.unquote_plus(encoded_url)
-    assert url.lower().startswith('http://') or url.lower().startswith('https://'), url
-    return redirect(url)
+    context = dict(url = url)
+    return render(request, 'url_forward/redirect.html', context)

--- a/django/url_forward/views.py
+++ b/django/url_forward/views.py
@@ -4,6 +4,6 @@ from django.shortcuts import render
 
 
 def do_redirect(request, encoded_url):
-    url = base64.b64encode(encoded_url.encode(encoding='utf-8'))
+    url = base64.b64decode(encoded_url.encode('utf-8')).decode('utf-8')
     context = dict(url = url)
     return render(request, 'url_forward/redirect.html', context)


### PR DESCRIPTION
`forward_url.get_redirect_url_to`: Retrieves a URL which redirects the client to the given URL.

`forward_url.views.do_redirect`: Performs redirection of the client to the given URL using JavaScript.